### PR TITLE
Safer way to get post_id in content filter

### DIFF
--- a/public/class-amazonpolly-public.php
+++ b/public/class-amazonpolly-public.php
@@ -93,17 +93,12 @@ class Amazonpolly_Public {
 	 */
 	public function content_filter( $content ) {
 
-		// Really strange case
-		if (!isset($GLOBALS)) {
+		$post_id = get_the_ID();
+
+		if ( empty( $post_id ) ) {
 			return $content;
-		} else {
-			if (!array_key_exists('post', $GLOBALS)) {
-				return $content;
-			}
 		}
 
-
-		$post_id = $GLOBALS['post']->ID;
 		$common = new AmazonAI_Common();
 
 		$source_language = $common->get_post_source_language($post_id);


### PR DESCRIPTION
*Description of changes:*
Modifying how the `Amazonpolly_Public::content_filter` method gets the current post ID. Current code pulls the ID directly from `$GLOBALS`. This PR changes that behavior to use the WordPress function [get_the_ID](https://developer.wordpress.org/reference/functions/get_the_id/). 

`get_the_ID` adds some extra checks that ensure the code won't throw errors if the `$GLOBALS['post']` property isn't an instance of `WP_Post`. This can happen when calling `wp_insert_attachment` programmatically.

Specifically, [the line below](https://github.com/awslabs/amazon-polly-wordpress-plugin/blob/master/public/class-amazonpolly-public.php#L106) gets the ID property from `$GLOBALS['post']` without checking to see if it exists first.

```php
$post_id = $GLOBALS['post']->ID;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
